### PR TITLE
Resolve link to home page social image

### DIFF
--- a/functions/images.js
+++ b/functions/images.js
@@ -44,6 +44,17 @@ const path = require("path");
     await page.evaluate((post) => {
       const title = document.querySelector("h1");
       title.innerHTML = post.title;
+
+      const subtitle = document.querySelector("h2");
+      const byline = document.querySelector("p");
+
+      if (post.slug === "home") {
+        subtitle.removeAttribute("hidden");
+        byline.setAttribute("hidden", "true");
+      } else {
+        subtitle.setAttribute("hidden", "true");
+        byline.removeAttribute("hidden");
+      }
     }, post);
 
     console.log(`Image: ${post.slug}.png`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "11ty-netlify-jumpstart",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "11ty-netlify-jumpstart",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/_generate/social-previews.njk
+++ b/src/_generate/social-previews.njk
@@ -22,6 +22,7 @@ eleventyExcludeFromCollections: true
     <header class="tdbc-hero tdbc-text-align-center">
       <div class="tdbc-container tdbc-content-maxlength">
         <h1 class="tdbc-ink--primary tdbc-mb-none tdbc-mlg"></h1>
+        <h2 class="tdbc-lead tdbc-mt-sm" hidden>{{ meta.siteDescription }}</h2>
         <p class="tdbc-lead tdbc-ink--gray tdbc-mt-md tdbc-mb-none">
           <span><em>Published on</em> <strong class="tdbc-ink--secondary">{{ meta.siteName }}</strong></span>
         </p>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -2,7 +2,7 @@
 <html lang="en">
 {%- set pageTitle %}{% if title %}{{ title }} | {% endif %}{{ meta.siteName }}{% endset -%}
 {%- set pageDescription %}{% if description %}{{ description }}{% else %}{{ meta.siteDescription }}{% endif %}{% endset -%}
-{%- set pageSocialImg %}{{ meta.url }}/previews/{{ title | slug }}.png{% endset -%}
+{%- set pageSocialImg %}{{ meta.url }}/previews/{% if title %}{{ title | slug }}{% else %}home{% endif %}.png{% endset -%}
   <head>
     <!-- Generated from the 11ty Netlify Jumpstart: https://github.com/5t3ph/11ty-netlify-jumpstart -->
     <meta charset="UTF-8" />


### PR DESCRIPTION
- display `meta.siteDescription` on home page image instead of "byline"

Closes #9 